### PR TITLE
update before installing ros-jazzy-librealsense2

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -35,6 +35,7 @@ RUN apt-get install -y ros-jazzy-py-binding-tools
 # colcon utils
 RUN apt-get install -y python3-colcon-clean python3-colcon-mixin
 # realsense drivers
+RUN apt-get update
 RUN apt-get install -y ros-jazzy-librealsense2*
 # pyaudio
 RUN apt-get install -y python3-pyaudio


### PR DESCRIPTION
Suddenly, apt was no longer able to resolve ros-jazzy-librealsense2*.
Calling "apt-get update" before installing the realsense stuff fixed this problem.