### PR TITLE
add GPU / CUDA support to docker container of xpra GUI

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -28,6 +28,14 @@ The container within the same network as the host and in `--priviledged` mode (r
 
 Porting the current user to the docker container is unfortunately essential to enable a seamless xpra integration. Using this setup, you will be able to authenticate in your xpra session with the same user and password as on your host.
 
+Optional: enable GPU / CUDA (12.8) support with arg `gpu`.
+
+```
+./docker_configuration gpu
+```
+
+Note: for GPU and CUDA support in the docker container you would need to install the Nvidia Container Toolkit on your host machine; refer: [Nvidia's install guide](https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/latest/install-guide.html)
+
 ## ```build_doc.sh```
 
 Creates a `venv`, downloads the required python packages and creates an `mkdocs` documentation page (on http://127.0.0.1:8000/).

--- a/scripts/docker_configuration.sh
+++ b/scripts/docker_configuration.sh
@@ -5,6 +5,12 @@ echo " ▐▌   ▐▌ ▐▌▐▛▚▖▐▌  █ ▐▌ ▐▌  █  ▐▛�
 echo " ▐▌   ▐▌ ▐▌▐▌ ▝▜▌  █ ▐▛▀▜▌  █  ▐▌ ▝▜▌▐▛▀▀▘▐▛▀▚▖    ▐▛▀▚▖▐▌ ▐▌  █  ▐▌   ▐▌  █ "
 echo " ▝▚▄▄▖▝▚▄▞▘▐▌  ▐▌  █ ▐▌ ▐▌▗▄█▄▖▐▌  ▐▌▐▙▄▄▖▐▌ ▐▌    ▐▙▄▞▘▝▚▄▞▘▗▄█▄▖▐▙▄▄▖▐▙▄▄▀ "
 
+# Check for additional args (currently only "gpu" is supported)
+ARGS="${1:-}"
+# set the name for the image and the container
+IMAGE_NAME="cobot_noble_image"
+CONTAINER_NAME="cobot_container"
+
 # This should be run from script directory
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 if [ "$PWD" != "$SCRIPT_DIR" ]; then 
@@ -17,10 +23,10 @@ if [ ! -e "../.devcontainer/Dockerfile" ]; then
     exit
 fi
 
-# create the Ubuntu 24.04 image with required configuration (refer Dockerfile for more information)
+# Create the Ubuntu 24.04 image with required configuration (refer Dockerfile for more information)
 # and add current user to docker container
 echo "============== Build container =============="
-docker build --build-arg USERNAME=${USER} --build-arg USER_ID=${UID} --build-arg GROUP_ID=$(id -r -g $UID) -t cobot_noble_image ../.devcontainer
+docker build --build-arg USERNAME=${USER} --build-arg USER_ID=${UID} --build-arg GROUP_ID=$(id -r -g $UID) -t "$IMAGE_NAME" ../.devcontainer
 echo ""
 
 echo "============== Start container =============="
@@ -28,18 +34,31 @@ echo "============== Start container =============="
 # bind local home directory to docker container (careful: you have write access to your host home directory),
 # run as current user (with corresponding user id and group id)
 # takeover X11 and password configs => this way we take over the username / passwords from the host machine
-# use GPU drivers of host
-docker run -itd \
-            --privileged \
-            --mount type=bind,src=/home/${USER},dst=/home/${USER} \
-            --user=${UID}:${GID} -w /home/${USER} \
-            --volume /etc/shadow:/etc/shadow \
-            --volume /run/dbus/system_bus_socket:/run/dbus/system_bus_socket \
-            --network host \
-            --device=/dev/bus/usb:/dev/bus/usb \
-            --rm \
-            --entrypoint /bin/bash \
-            --name cobot_container cobot_noble_image
+DOCKER_ARGS=(
+    -itd \
+    --privileged \
+    --mount type=bind,src=/home/${USER},dst=/home/${USER} \
+    --user=${UID}:${GID} -w /home/${USER} \
+    --volume /etc/shadow:/etc/shadow \
+    --volume /run/dbus/system_bus_socket:/run/dbus/system_bus_socket \
+    --network host \
+    --device=/dev/bus/usb:/dev/bus/usb \
+    --rm \
+    --entrypoint /bin/bash \
+    --name "$CONTAINER_NAME" \
+)
+
+# Add GPU / CUDA support if requested
+if [[ "$ARGS" == "gpu" ]]; then
+  DOCKER_ARGS+=(
+    --runtime=nvidia \
+    --gpus all \
+    --volume /usr/local/cuda-12.8:/usr/local/cuda-12.8 \
+  )
+fi
+
+# Start the container
+docker run "${DOCKER_ARGS[@]}" "$IMAGE_NAME"
 echo ""
 
 # rharbach: deactivated (not required for now)


### PR DESCRIPTION
In some cases we need GPU support. This PR adds an option to add GPU / CUDA support to the docker container for xpra.